### PR TITLE
[22/06/06] 전체 동영상 조회 기능

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const cors = require("cors");
 
 const passport = require("./config/passport");
 const authRouter = require("./routes/auth");
+const videoRouter = require("./routes/video");
 
 const app = express();
 
@@ -38,6 +39,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
 
 app.use("/api/auth", authRouter);
+app.use("/api/videos", videoRouter);
 
 app.use((req, res, next) => {
   next(createError(404));

--- a/controllers/video.js
+++ b/controllers/video.js
@@ -1,0 +1,17 @@
+const VideoService = require("../services/VideoService");
+
+exports.getVideoLists = async (req, res, next) => {
+  try {
+    const videoLists = await VideoService.findVideoLists();
+
+    return res.status(201).json({
+      result: "ok",
+      data: videoLists,
+    });
+  } catch (err) {
+    return res.status(500).json({
+      result: "ng",
+      errorMessage: "cannot get all videos. try again.",
+    });
+  }
+};

--- a/controllers/video.js
+++ b/controllers/video.js
@@ -2,7 +2,7 @@ const VideoService = require("../services/VideoService");
 
 exports.getVideoList = async (req, res, next) => {
   try {
-    const videoLists = await VideoService.findVideoLists();
+    const videoLists = await VideoService.findVideoList();
 
     return res.status(201).json({
       result: "ok",

--- a/controllers/video.js
+++ b/controllers/video.js
@@ -1,12 +1,12 @@
 const VideoService = require("../services/VideoService");
 
-exports.getVideoLists = async (req, res, next) => {
+exports.getVideoList = async (req, res, next) => {
   try {
     const videoLists = await VideoService.findVideoLists();
 
     return res.status(201).json({
       result: "ok",
-      data: videoLists,
+      videos: videoLists,
     });
   } catch (err) {
     return res.status(500).json({

--- a/controllers/video.js
+++ b/controllers/video.js
@@ -2,11 +2,11 @@ const VideoService = require("../services/VideoService");
 
 exports.getVideoList = async (req, res, next) => {
   try {
-    const videoLists = await VideoService.findVideoList();
+    const videoList = await VideoService.findVideoList();
 
     return res.status(201).json({
       result: "ok",
-      videos: videoLists,
+      videos: videoList,
     });
   } catch (err) {
     return res.status(500).json({

--- a/models/Video.js
+++ b/models/Video.js
@@ -22,7 +22,7 @@ const VideoSchema = new mongoose.Schema(
     ],
     dueDate: {
       type: Date,
-      required: true,
+      required: [true, "dueDate not specified"],
     },
   },
   { timestamps: true },

--- a/models/Video.js
+++ b/models/Video.js
@@ -1,0 +1,26 @@
+const mongoose = require("mongoose");
+
+const VideoSchema = new mongoose.Schema({
+  title: {
+    type: String,
+    required: [true, "title not specified"],
+  },
+  videoUrl: {
+    type: String,
+    required: [true, "videoUrl not specified"],
+  },
+  thumbUrl: {
+    type: String,
+    required: [true, "thumbUrl not specified"],
+  },
+  creators: [ {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+  }],
+  dueDate: {
+    type: Date,
+    required: true,
+  },
+}, { timestamps: true });
+
+module.exports = mongoose.model("Video", VideoSchema);

--- a/models/Video.js
+++ b/models/Video.js
@@ -1,26 +1,31 @@
 const mongoose = require("mongoose");
 
-const VideoSchema = new mongoose.Schema({
-  title: {
-    type: String,
-    required: [true, "title not specified"],
+const VideoSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: [true, "title not specified"],
+    },
+    videoUrl: {
+      type: String,
+      required: [true, "videoUrl not specified"],
+    },
+    thumbUrl: {
+      type: String,
+      required: [true, "thumbUrl not specified"],
+    },
+    creators: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+      },
+    ],
+    dueDate: {
+      type: Date,
+      required: true,
+    },
   },
-  videoUrl: {
-    type: String,
-    required: [true, "videoUrl not specified"],
-  },
-  thumbUrl: {
-    type: String,
-    required: [true, "thumbUrl not specified"],
-  },
-  creators: [ {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: "User",
-  }],
-  dueDate: {
-    type: Date,
-    required: true,
-  },
-}, { timestamps: true });
+  { timestamps: true },
+);
 
 module.exports = mongoose.model("Video", VideoSchema);

--- a/routes/video.js
+++ b/routes/video.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const videoRouter = express.Router();
-const { getVideoLists } = require("../controllers/video");
+const { getVideoList } = require("../controllers/video");
 
-videoRouter.get("/", getVideoLists);
+videoRouter.get("/", getVideoList);
 
 module.exports = videoRouter;

--- a/routes/video.js
+++ b/routes/video.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const videoRouter = express.Router();
+const { getVideoLists } = require("../controllers/video");
+
+videoRouter.get("/", getVideoLists);
+
+module.exports = videoRouter;

--- a/services/VideoService.js
+++ b/services/VideoService.js
@@ -1,5 +1,5 @@
 const Video = require("../models/Video");
 
 exports.findVideoLists = async () => {
-  return await Video.find(objectId).lean();
+  return await Video.find().lean();
 };

--- a/services/VideoService.js
+++ b/services/VideoService.js
@@ -1,0 +1,5 @@
+const Video = require("../models/Video");
+
+exports.findVideoLists = async () => {
+  return await Video.find(objectId).lean();
+};

--- a/services/VideoService.js
+++ b/services/VideoService.js
@@ -1,5 +1,5 @@
 const Video = require("../models/Video");
 
-exports.findVideoLists = async () => {
+exports.findVideoList = async () => {
   return await Video.find().lean();
 };


### PR DESCRIPTION
## 주제
전체 동영상 조회 기능

## 작업사항
* Video Mongoose Schema 작성
* Video 라우터 추가 ("/api/videos)
* Video 컨트롤러 및 동영상 조회 관련 getVideoLists 메서드 추가
* mongoDB 조회 등 비즈니스 로직에 대한 Service 계층 분리 및 findVideoLists 메서드 추가

### 변경사항
* Video Mongoose Schema
title, videoUrl, thumbUrl, creators 및 dueDate에 대한 항목으로 구성되어 있습니다.
현재 몽구스 [SchemaType Options] 으로 required만 추가하였는데, 혹시 추가적으로 필요할 옵션이 있을까요?
타이틀은 굳이 unique할 필요가 없고, 길이도 프론트에서 줄여서 보여주면 될 것 같습니다.
비디오 및 썸네일 주소는 aws에 저장되면 다른 주소이므로 별도로 설정하지 않았습니다.

* VideoService.js
MongoDB로 데이터를 조회하는 메서드입니다. 만약 이 데이터를 가져오는 도중 오류가 발생한다면 videoController의 try-catch 구문에서 처리될 예정입니다.

* videoController 
VideoService의 findVideoLists 메서드를 사용하여 비디오 리스트를 가져온 후 데이터를 프론트로 보냅니다.
성공과 실패에 대한 status 및 result는 칸반 기준으로 작성하였습니다.
[칸반](https://www.notion.so/vanillacoding/BE-f722dac0e3284b338dfd6e1fc1a8f616)

## 기타
1. 함수명이 적절한지 의견 부탁 드립니다.
2. 현재 컨트롤러는 video.js로 되어 있고 서비스는 VideoServices로 되어있는데 컨트롤러도 서비스 파일명과 통일하는 것이 좋을까요?
