### PR TITLE
[2022/06/15] fluent-ffmpeg 이용하여 gif 편집 기능 추가 (필터 효과 & 콜라주)

### DIFF
--- a/constants/gif-filter-options.js
+++ b/constants/gif-filter-options.js
@@ -1,0 +1,256 @@
+exports.GRID_2 = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "4",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d"],
+  },
+  "[a][b]hstack=inputs=2[first]",
+  "[c][d]hstack=inputs=2[second]",
+  "[first][second]vstack=inputs=2",
+];
+
+exports.GRID_3 = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "9",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+  },
+  "[a][b][c]hstack=inputs=3[first]",
+  "[d][e][f]hstack=inputs=3[second]",
+  "[g][h][i]hstack=inputs=3[third]",
+  "[first][second][third]vstack=inputs=3",
+];
+
+exports.GRID_4 = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "16",
+    inputs: "rescaled",
+    outputs: [
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "k",
+      "l",
+      "m",
+      "n",
+      "o",
+      "p",
+    ],
+  },
+  "[a][b][c][d]hstack=inputs=4[first]",
+  "[e][f][g][h]hstack=inputs=4[second]",
+  "[i][j][k][l]hstack=inputs=4[third]",
+  "[m][n][o][p]hstack=inputs=4[fourth]",
+  "[first][second][thrid][fourth]vstack=inputs=4",
+];
+
+exports.SEPIA = [
+  "scale=240:360[rescaled]",
+  "[rescaled]colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131",
+];
+
+exports.GRAYSCALE = ["scale=240:360[rescaled]", "[rescaled]hue=s=0"];
+
+exports.REVERSAL = [
+  "scale=240:360[rescaled]",
+  "[rescaled]edgedetect=enable='gt(mod(t,60),57)', negate",
+];
+
+exports.GRID_2_SEPIA = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "4",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d"],
+  },
+  "[a][b]hstack=inputs=2[first]",
+  "[c][d]hstack=inputs=2[second]",
+  "[first][second]vstack=inputs=2[grid]",
+  "[grid]colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131",
+];
+
+exports.GRID_2_GRAYSCALE = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "4",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d"],
+  },
+  "[a][b]hstack=inputs=2[first]",
+  "[c][d]hstack=inputs=2[second]",
+  "[first][second]vstack=inputs=2[grid]",
+  "[grid]hue=s=0",
+];
+
+exports.GRID_2_REVERSAL = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "4",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d"],
+  },
+  "[a][b]hstack=inputs=2[first]",
+  "[c][d]hstack=inputs=2[second]",
+  "[first][second]vstack=inputs=2[grid]",
+  "[grid]edgedetect=enable='gt(mod(t,60),57)', negate",
+];
+
+exports.GRID_3_SEPIA = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "9",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+  },
+  "[a][b][c]hstack=inputs=3[first]",
+  "[d][e][f]hstack=inputs=3[second]",
+  "[g][h][i]hstack=inputs=3[third]",
+  "[first][second][third]vstack=inputs=3[grid]",
+  "[grid]colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131",
+];
+
+exports.GRID_3_GRAYSCALE = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "9",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+  },
+  "[a][b][c]hstack=inputs=3[first]",
+  "[d][e][f]hstack=inputs=3[second]",
+  "[g][h][i]hstack=inputs=3[third]",
+  "[first][second][third]vstack=inputs=3[grid]",
+  "[grid]hue=s=0",
+];
+
+exports.GRID_3_REVERSAL = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "9",
+    inputs: "rescaled",
+    outputs: ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+  },
+  "[a][b][c]hstack=inputs=3[first]",
+  "[d][e][f]hstack=inputs=3[second]",
+  "[g][h][i]hstack=inputs=3[third]",
+  "[first][second][third]vstack=inputs=3[grid]",
+  "[grid]edgedetect=enable='gt(mod(t,60),57)', negate",
+];
+
+exports.GRID_4_SEPIA = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "16",
+    inputs: "rescaled",
+    outputs: [
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "k",
+      "l",
+      "m",
+      "n",
+      "o",
+      "p",
+    ],
+  },
+  "[a][b][c][d]hstack=inputs=4[first]",
+  "[e][f][g][h]hstack=inputs=4[second]",
+  "[i][j][k][l]hstack=inputs=4[third]",
+  "[m][n][o][p]hstack=inputs=4[fourth]",
+  "[first][second][third][fourth]vstack=inputs=4[grid]",
+  "[grid]colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131",
+];
+
+exports.GRID_4_GRAYSCALE = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "16",
+    inputs: "rescaled",
+    outputs: [
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "k",
+      "l",
+      "m",
+      "n",
+      "o",
+      "p",
+    ],
+  },
+  "[a][b][c][d]hstack=inputs=4[first]",
+  "[e][f][g][h]hstack=inputs=4[second]",
+  "[i][j][k][l]hstack=inputs=4[third]",
+  "[m][n][o][p]hstack=inputs=4[fourth]",
+  "[first][second][third][fourth]vstack=inputs=4[grid]",
+  "[grid]hue=s=0",
+];
+
+exports.GRID_4_REVERSAL = [
+  "scale=90:160[rescaled]",
+  {
+    filter: "split",
+    options: "16",
+    inputs: "rescaled",
+    outputs: [
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "k",
+      "l",
+      "m",
+      "n",
+      "o",
+      "p",
+    ],
+  },
+  "[a][b][c][d]hstack=inputs=4[first]",
+  "[e][f][g][h]hstack=inputs=4[second]",
+  "[i][j][k][l]hstack=inputs=4[third]",
+  "[m][n][o][p]hstack=inputs=4[fourth]",
+  "[first][second][third][fourth]vstack=inputs=4[grid]",
+  "[grid]edgedetect=enable='gt(mod(t,60),57)', negate",
+];

--- a/controllers/video.js
+++ b/controllers/video.js
@@ -92,10 +92,10 @@ exports.updateVideo = async (req, res, next) => {
 };
 
 exports.createGif = async (req, res, next) => {
-  const { videoUrl, fps } = req.body;
+  const { videoUrl, filter } = req.body;
 
   try {
-    const convertedGif = await convertGif(videoUrl, fps);
+    const convertedGif = await convertGif(videoUrl, filter);
     const newGif = await uploadVideoToAWS(convertedGif, "gif");
     fs.unlinkSync(path.join(__dirname, `../${convertedGif}`));
 

--- a/services/FFmpegService.js
+++ b/services/FFmpegService.js
@@ -26,7 +26,7 @@ exports.concatVideos = (originVideo, newVideo) => {
 };
 
 exports.convertGif = (originVideo, filter) => {
-  const { color, grid, fps } = filter;
+  const { color, grid, fps = 15 } = filter;
   const filename = `${now}_${randomStr}.gif`;
 
   const getGifOption = (color, grid) => {

--- a/services/FFmpegService.js
+++ b/services/FFmpegService.js
@@ -4,6 +4,7 @@ const ffprobePath = require("@ffprobe-installer/ffprobe").path;
 ffmpeg.setFfmpegPath(ffmpegPath);
 ffmpeg.setFfprobePath(ffprobePath);
 
+const gifFilterOptions = require("../constants/gif-filter-options");
 const randomStr = Math.random().toString(36).substring(2, 12);
 const now = Date.now();
 
@@ -24,17 +25,89 @@ exports.concatVideos = (originVideo, newVideo) => {
   });
 };
 
-exports.convertGif = (originVideo, fps) => {
+exports.convertGif = (originVideo, filter) => {
+  const { color, grid, fps } = filter;
   const filename = `${now}_${randomStr}.gif`;
+
+  const getGifOption = (color, grid) => {
+    if (!color && !grid) {
+      return "";
+    }
+
+    if (!color) {
+      if (grid === "2x2") {
+        return gifFilterOptions.GRID_2;
+      }
+
+      if (grid === "3x3") {
+        return gifFilterOptions.GRID_3;
+      }
+
+      if (grid === "4x4") {
+        return gifFilterOptions.GRID_4;
+      }
+    }
+
+    if (color === "SEPIA") {
+      if (!grid) {
+        return gifFilterOptions.SEPIA;
+      }
+
+      if (grid === "2x2") {
+        return gifFilterOptions.GRID_2_SEPIA;
+      }
+
+      if (grid === "3x3") {
+        return gifFilterOptions.GRID_3_SEPIA;
+      }
+
+      if (grid === "4x4") {
+        return gifFilterOptions.GRID_4_SEPIA;
+      }
+    }
+
+    if (color === "GRAYSCALE") {
+      if (!grid) {
+        return gifFilterOptions.GRAYSCALE;
+      }
+
+      if (grid === "2x2") {
+        return gifFilterOptions.GRID_2_GRAYSCALE;
+      }
+
+      if (grid === "3x3") {
+        return gifFilterOptions.GRID_3_GRAYSCALE;
+      }
+
+      if (grid === "4x4") {
+        return gifFilterOptions.GRID_4_GRAYSCALE;
+      }
+    }
+
+    if (color === "REVERSAL") {
+      if (!grid) {
+        return gifFilterOptions.REVERSAL;
+      }
+
+      if (grid === "2x2") {
+        return gifFilterOptions.GRID_2_REVERSAL;
+      }
+
+      if (grid === "3x3") {
+        return gifFilterOptions.GRID_3_REVERSAL;
+      }
+
+      if (grid === "4x4") {
+        return gifFilterOptions.GRID_4_REVERSAL;
+      }
+    }
+  };
 
   return new Promise((resolve, reject) => {
     ffmpeg(originVideo)
-      .size("360x640")
+      .complexFilter(getGifOption(color, grid))
       .fps(fps)
       .output(`./${filename}`)
-      .on("error", (err) => {
-        console.log("error: ", err);
-      })
       .on("end", (err) => {
         if (!err) {
           console.log("conversion Done");


### PR DESCRIPTION
## 주제
- fluent-ffmpeg 이용하여 gif 편집 기능 추가 (필터 효과 & 콜라주)

## 작업사항
- fluent-ffmpeg 이용하여 video에서 gif로 변환 전 편집을 할 수 있도록 기존의 createGif 함수를 수정했습니다

## 변경사항
- fluent-ffmpeg 이용하여 video에서 gif로 변환 전에 편집할 수 있는 기능을 추가했습니다
- gif 필터 효과를 추가했습니다. 흑백, 세피아, 반전 효과를 추가했습니다
- gif 콜라주(같은 사진 여러 개를 바둑판 식으로 보여주는 하나의 gif 파일)을 만드는 기능을 추가했습니다
- 사용자는 두 가지 편집 기능의 각 옵션들을 서로 조합하여 변환된 gif 파일을 받을 수 있습니다

## 기타
- fluent-ffmpeg의 complexFilter 부분 관련하여 리팩토링이 필요해 보입니다. 코드를 수정하여 재사용 가능하게 수정할 수 있을 것 같습니다. 추후 1차 기능 구현이 완료되면 꼭 리팩토링 하도록 하겠습니다!